### PR TITLE
Additions to temlate (gif to png) to avoid causing issues with backwards compatibility

### DIFF
--- a/Products/PloneHelpCenter/skins/plone_help_center/helpcenter_view.pt
+++ b/Products/PloneHelpCenter/skins/plone_help_center/helpcenter_view.pt
@@ -76,7 +76,8 @@
         </p>
     
         <p>
-          <img tal:replace="structure here/rss.png" />
+          <img tal:replace="structure here/rss.png" tal:condition="here/rss.png" />
+          <img tal:replace="structure here/rss.gif" tal:condition="here/rss.gif" />
           <a tal:attributes="href view/getSyndicationURL" 
              i18n:translate="phc_rss_all">
             Feed for all documentation.


### PR DESCRIPTION
Added an extra line for here/rss.gif, now has a condition to check for existance of .gif and an extra line however for  the .png  variant. This should increase backwards compatibility for anyone who installs this version on Plone 4.2.5 (still has gif) however Plone 4.3 only has png and throws the error.

To avoid this problem: http://plone.org/products/plonehelpcenter/issues/167 but also keep backwards compatibility.
